### PR TITLE
fix: do not crash on load_dict function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -701,7 +701,7 @@ pub fn load_wordlist(path: &Path) -> io::Result<Vec<String>> {
 }
 
 pub fn load_dict(path: &Path) -> io::Result<Dict> {
-    let wordlist = load_wordlist(path).unwrap();
+    let wordlist = load_wordlist(path)?;
     let wordlist: Vec<_> = wordlist.iter().map(|w| &w[..]).collect();
     return Ok(create_prefix_tree(&wordlist));
 }


### PR DESCRIPTION
จากโค้ด

```rust
use wordcut_engine::load_dict;
use wordcut_engine::Wordcut;
use std::path::Path;

fn main() {
    let dict_path = Path::new(concat!(
        env!("CARGO_MANIFEST_DIR"),
        "/not_found.txt"
    ));
    if let Ok(dict) = load_dict(dict_path) {
	let wordcut = Wordcut::new(dict);
	println!("{}", wordcut.put_delimiters("หมากินไก่", "|"));
    }
}
```

ตัว library เองจะ crash หากไฟล์ dictionary ไม่มีอยู่จริง ตาม error ด้านล่าง:

```
$ cargo run
   Compiling wordcut-engine-example v0.0.1 (/Users/thanabodee/src/github.com/veer66/wordcut-engine/example)
    Finished dev [unoptimized + debuginfo] target(s) in 0.56s
     Running `target/debug/wordcut-engine-example`
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }', /Users/thanabodee/src/github.com/veer66/wordcut-engine/src/lib.rs:704:40
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

patch นี้แก้ให้ตัว function `load_dict` คืน `std::io::Error` แทนที่จะ crash ด้วย `unwrap` หลังจากแก้ไข code ตัวอย่างด้านบนจะไม่เกิดอาการ crash แต่จะคืน error จาก io แทน หรือจะ force ให้ crash ได้ด้วย `unwrap` จาก caller แทน